### PR TITLE
feat: add course price API endpoint.

### DIFF
--- a/tests/test_api_views.py
+++ b/tests/test_api_views.py
@@ -120,3 +120,218 @@ class CoursePriceViewTest(APITestCase):
         self.assertEqual(response.status_code, http_status.HTTP_404_NOT_FOUND)
         assert 'error' in response.data
         assert 'No pricing modes available' in response.data['error']
+
+    def test_get_price_cache_hit(self):
+        """
+        Verify that API returns cached data on subsequent requests.
+        """
+        url = reverse('zeitlabs_payments:course-price')
+        course_id = 'course-v1:org1+1+1'
+        response1 = self.client.get(url, {'course_id': course_id})
+        self.assertEqual(response1.status_code, http_status.HTTP_200_OK)
+        response2 = self.client.get(url, {'course_id': course_id})
+        self.assertEqual(response2.status_code, http_status.HTTP_200_OK)
+        self.assertEqual(response1.data, response2.data)
+
+    def test_get_price_cache_invalidation_on_catalogue_item_update(self):
+        """
+        Verify that cache is invalidated when CatalogueItem price changes.
+        """
+
+        url = reverse('zeitlabs_payments:course-price')
+        course_id = 'course-v1:org1+1+1'
+        response1 = self.client.get(url, {'course_id': course_id})
+        response1.data['pricing_modes'][0]['price']
+        self.assertEqual(response1.status_code, http_status.HTTP_200_OK)
+        catalogue_item = CatalogueItem.objects.filter(
+            item_ref_id=course_id, type=CatalogueItem.ItemType.PAID_COURSE
+        ).first()
+        from decimal import Decimal
+
+        for exists in (True, False):
+            if exists:
+                catalogue_item = CatalogueItem.objects.filter(
+                    item_ref_id=course_id, type=CatalogueItem.ItemType.PAID_COURSE
+                ).first()
+            else:
+                CatalogueItem.objects.filter(
+                    item_ref_id=course_id, type=CatalogueItem.ItemType.PAID_COURSE
+                ).delete()
+                catalogue_item = CatalogueItem.objects.filter(
+                    item_ref_id=course_id, type=CatalogueItem.ItemType.PAID_COURSE
+                ).first()
+
+            if catalogue_item:
+                new_price = Decimal('999.99')
+                catalogue_item.price = new_price
+                catalogue_item.save()
+                response2 = self.client.get(url, {'course_id': course_id})
+                self.assertEqual(response2.status_code, http_status.HTTP_200_OK)
+                self.assertEqual(response2.data['pricing_modes'][0]['price'], new_price)
+            else:
+                self.assertIsNone(catalogue_item)
+
+    def test_get_price_cache_invalidation_on_catalogue_item_delete(self):
+        """
+        Verify that cache is invalidated when CatalogueItem is deleted.
+        """
+        from common.djangoapps.course_modes.models import CourseMode
+        from opaque_keys.edx.keys import CourseKey
+
+        course_id = 'course-v1:org1+orphan+2026'
+        CourseOverview.objects.create(
+            id=course_id, org='org1', display_name='Orphan Course'
+        )
+
+        catalogue_item = CatalogueItem.objects.create(
+            sku='orphan-sku-test',
+            type=CatalogueItem.ItemType.PAID_COURSE,
+            title='Orphan Catalogue Item',
+            item_ref_id=course_id,
+            price=100,
+            currency='IQD',
+        )
+        course_key = CourseKey.from_string(course_id)
+        CourseMode.objects.create(
+            course_id=course_key,
+            mode_slug='verified',
+            mode_display_name='Verified',
+            sku=catalogue_item.sku,
+            min_price=50,
+        )
+
+        url = reverse('zeitlabs_payments:course-price')
+        response1 = self.client.get(url, {'course_id': course_id})
+        self.assertEqual(response1.status_code, http_status.HTTP_200_OK)
+        catalogue_item.delete()
+        response2 = self.client.get(url, {'course_id': course_id})
+        self.assertEqual(response2.status_code, http_status.HTTP_404_NOT_FOUND)
+
+    def test_get_price_cache_invalidation_on_course_mode_delete(self):
+        """
+        Verify that cache is invalidated when CourseMode is deleted.
+        """
+        from common.djangoapps.course_modes.models import CourseMode
+        from opaque_keys.edx.keys import CourseKey
+
+        url = reverse('zeitlabs_payments:course-price')
+        course_id = 'course-v1:org1+1+1'
+        response1 = self.client.get(url, {'course_id': course_id})
+        self.assertEqual(response1.status_code, http_status.HTTP_200_OK)
+        course_key = CourseKey.from_string(course_id)
+        for exists in (True, False):
+            if exists:
+                course_mode = CourseMode.objects.filter(course_id=course_key).first()
+            else:
+                CourseMode.objects.filter(course_id=course_key).delete()
+                course_mode = CourseMode.objects.filter(course_id=course_key).first()
+
+            if course_mode:
+                course_mode.delete()
+                self.client.get(url, {'course_id': course_id})
+            else:
+                self.assertIsNone(course_mode)
+
+    def test_get_price_cache_invalidation_catalogue_item_not_found(self):
+        """
+        Verify cache invalidation handler handles missing CatalogueItem gracefully.
+        Tests the edge case where catalogue_item filter returns None.
+        """
+        url = reverse('zeitlabs_payments:course-price')
+        course_id = 'course-v1:org1+orphan+2026'
+        CourseOverview.objects.create(
+            id=course_id, org='org1', display_name='Orphan Course'
+        )
+
+        CatalogueItem.objects.create(
+            sku='orphan-sku',
+            type=CatalogueItem.ItemType.PAID_COURSE,
+            title='Orphan Catalogue Item',
+            item_ref_id=course_id,
+            price=100,
+            currency='IQD',
+        )
+
+        from common.djangoapps.course_modes.models import CourseMode
+        from opaque_keys.edx.keys import CourseKey
+
+        course_key = CourseKey.from_string(course_id)
+        CourseMode.objects.create(
+            course_id=course_key,
+            mode_slug='verified',
+            mode_display_name='Verified',
+            sku='orphan-sku',
+            min_price=50,
+        )
+
+        response1 = self.client.get(url, {'course_id': course_id})
+        self.assertEqual(response1.status_code, http_status.HTTP_200_OK)
+
+        for exists in (True, False):
+            if exists:
+                catalogue_item = CatalogueItem.objects.filter(
+                    item_ref_id=course_id, type=CatalogueItem.ItemType.PAID_COURSE
+                ).first()
+            else:
+                CatalogueItem.objects.filter(
+                    item_ref_id=course_id, type=CatalogueItem.ItemType.PAID_COURSE
+                ).delete()
+                catalogue_item = CatalogueItem.objects.filter(
+                    item_ref_id=course_id, type=CatalogueItem.ItemType.PAID_COURSE
+                ).first()
+
+            if catalogue_item:
+                catalogue_item.delete()
+                response2 = self.client.get(url, {'course_id': course_id})
+                self.assertEqual(response2.status_code, http_status.HTTP_404_NOT_FOUND)
+            else:
+                self.assertIsNone(catalogue_item)
+
+    def test_get_price_cache_invalidation_course_mode_not_found(self):
+        """
+        Verify cache invalidation handler handles missing CourseMode gracefully.
+        Tests the edge case where course_mode filter returns None.
+        """
+        from common.djangoapps.course_modes.models import CourseMode
+        from opaque_keys.edx.keys import CourseKey
+
+        url = reverse('zeitlabs_payments:course-price')
+        course_id = 'course-v1:org1+orphan2+2024'
+        CourseOverview.objects.create(
+            id=course_id, org='org1', display_name='Orphan Course 2'
+        )
+
+        catalogue_item = CatalogueItem.objects.create(
+            sku='orphan-sku2',
+            type=CatalogueItem.ItemType.PAID_COURSE,
+            title='Orphan Catalogue Item 2',
+            item_ref_id=course_id,
+            price=100,
+            currency='IQD',
+        )
+
+        course_key = CourseKey.from_string(course_id)
+        CourseMode.objects.create(
+            course_id=course_key,
+            mode_slug='verified',
+            mode_display_name='Verified',
+            sku=catalogue_item.sku,
+            min_price=50,
+        )
+
+        response1 = self.client.get(url, {'course_id': course_id})
+        self.assertEqual(response1.status_code, http_status.HTTP_200_OK)
+
+        for exists in (True, False):
+            if exists:
+                course_mode = CourseMode.objects.filter(course_id=course_key).first()
+            else:
+                CourseMode.objects.filter(course_id=course_key).delete()
+                course_mode = CourseMode.objects.filter(course_id=course_key).first()
+
+            if course_mode:
+                course_mode.delete()
+                response2 = self.client.get(url, {'course_id': course_id})
+                self.assertEqual(response2.status_code, http_status.HTTP_404_NOT_FOUND)
+            else:
+                self.assertIsNone(course_mode)

--- a/tests/test_api_views.py
+++ b/tests/test_api_views.py
@@ -2,8 +2,11 @@
 
 import pytest
 from django.urls import reverse
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from rest_framework import status as http_status
 from rest_framework.test import APITestCase
+
+from zeitlabs_payments.models import CatalogueItem
 
 
 @pytest.mark.usefixtures('base_data')
@@ -87,6 +90,32 @@ class CoursePriceViewTest(APITestCase):
         course_without_modes = 'course-v1:org1+3+3'
 
         response = self.client.get(url, {'course_id': course_without_modes})
+
+        self.assertEqual(response.status_code, http_status.HTTP_404_NOT_FOUND)
+        assert 'error' in response.data
+        assert 'No pricing modes available' in response.data['error']
+
+    def test_get_price_catalogue_items_without_matching_modes(self):
+        """
+        Verify that the API returns 404 when catalogue items exist but have no matching course modes.
+        This tests the edge case where CatalogueItems exist but CourseMode.objects.filter() returns empty.
+        """
+        course_id = 'course-v1:org1+orphan+2026'
+        CourseOverview.objects.create(
+            id=course_id, org='org1', display_name='Orphan Course'
+        )
+
+        CatalogueItem.objects.create(
+            sku='orphan-sku',
+            type=CatalogueItem.ItemType.PAID_COURSE,
+            title='Orphan Catalogue Item',
+            item_ref_id=course_id,
+            price=100,
+            currency='IQD',
+        )
+
+        url = reverse('zeitlabs_payments:course-price')
+        response = self.client.get(url, {'course_id': course_id})
 
         self.assertEqual(response.status_code, http_status.HTTP_404_NOT_FOUND)
         assert 'error' in response.data

--- a/tests/test_api_views.py
+++ b/tests/test_api_views.py
@@ -1,0 +1,93 @@
+"""Test API views for anonymous access to course pricing information."""
+
+import pytest
+from django.urls import reverse
+from rest_framework import status as http_status
+from rest_framework.test import APITestCase
+
+
+@pytest.mark.usefixtures('base_data')
+class CoursePriceViewTest(APITestCase):
+    """Tests for CoursePriceView - Anonymous access to course pricing."""
+
+    def test_get_price_anonymous_success(self):
+        """
+        Verify that anonymous users can fetch course pricing information.
+        """
+        url = reverse('zeitlabs_payments:course-price')
+        course_id = 'course-v1:org1+1+1'
+
+        response = self.client.get(url, {'course_id': course_id})
+
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+
+        assert 'course' in response.data
+        assert 'pricing_modes' in response.data
+
+        course_data = response.data['course']
+        assert course_data['course_id'] == course_id
+        assert 'course_name' in course_data
+        assert 'course_image' in course_data
+        assert 'org' in course_data
+        assert 'run' in course_data
+
+        # Verify pricing modes
+        pricing_modes = response.data['pricing_modes']
+        assert isinstance(pricing_modes, list)
+        assert len(pricing_modes) > 0
+        assert 'mode_slug' in pricing_modes[0]
+        assert 'mode_display_name' in pricing_modes[0]
+        assert 'price' in pricing_modes[0]
+        assert 'currency' in pricing_modes[0]
+        assert 'sku' in pricing_modes[0]
+
+    def test_get_price_missing_course_id(self):
+        """
+        Verify that the API returns 400 when course_id is not provided.
+        """
+        url = reverse('zeitlabs_payments:course-price')
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+        assert 'error' in response.data
+        assert 'course_id parameter is required' in response.data['error']
+
+    def test_get_price_invalid_course_id(self):
+        """
+        Verify that the API returns 400 for invalid course_id format.
+        """
+        url = reverse('zeitlabs_payments:course-price')
+        invalid_course_id = 'invalid-course-id-format'
+
+        response = self.client.get(url, {'course_id': invalid_course_id})
+
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+        assert 'error' in response.data
+        assert 'Invalid course_id format' in response.data['error']
+
+    def test_get_price_course_not_found(self):
+        """
+        Verify that the API returns 404 when the course does not exist.
+        """
+        url = reverse('zeitlabs_payments:course-price')
+        non_existent_course = 'course-v1:NonExistent+Course+2024'
+
+        response = self.client.get(url, {'course_id': non_existent_course})
+
+        self.assertEqual(response.status_code, http_status.HTTP_404_NOT_FOUND)
+        assert 'error' in response.data
+        assert 'Course not found' in response.data['error']
+
+    def test_get_price_no_pricing_modes(self):
+        """
+        Verify that the API returns 404 when course exists but has no pricing modes with SKUs.
+        """
+        url = reverse('zeitlabs_payments:course-price')
+        course_without_modes = 'course-v1:org1+3+3'
+
+        response = self.client.get(url, {'course_id': course_without_modes})
+
+        self.assertEqual(response.status_code, http_status.HTTP_404_NOT_FOUND)
+        assert 'error' in response.data
+        assert 'No pricing modes available' in response.data['error']

--- a/tests/test_api_views.py
+++ b/tests/test_api_views.py
@@ -1,7 +1,11 @@
 """Test API views for anonymous access to course pricing information."""
 
+from decimal import Decimal
+
 import pytest
+from common.djangoapps.course_modes.models import CourseMode
 from django.urls import reverse
+from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from rest_framework import status as http_status
 from rest_framework.test import APITestCase
@@ -141,13 +145,10 @@ class CoursePriceViewTest(APITestCase):
         url = reverse('zeitlabs_payments:course-price')
         course_id = 'course-v1:org1+1+1'
         response1 = self.client.get(url, {'course_id': course_id})
-        response1.data['pricing_modes'][0]['price']
         self.assertEqual(response1.status_code, http_status.HTTP_200_OK)
         catalogue_item = CatalogueItem.objects.filter(
             item_ref_id=course_id, type=CatalogueItem.ItemType.PAID_COURSE
         ).first()
-        from decimal import Decimal
-
         for exists in (True, False):
             if exists:
                 catalogue_item = CatalogueItem.objects.filter(
@@ -175,8 +176,7 @@ class CoursePriceViewTest(APITestCase):
         """
         Verify that cache is invalidated when CatalogueItem is deleted.
         """
-        from common.djangoapps.course_modes.models import CourseMode
-        from opaque_keys.edx.keys import CourseKey
+        # CourseMode and CourseKey are imported at module level
 
         course_id = 'course-v1:org1+orphan+2026'
         CourseOverview.objects.create(
@@ -211,8 +211,7 @@ class CoursePriceViewTest(APITestCase):
         """
         Verify that cache is invalidated when CourseMode is deleted.
         """
-        from common.djangoapps.course_modes.models import CourseMode
-        from opaque_keys.edx.keys import CourseKey
+        # CourseMode and CourseKey are imported at module level
 
         url = reverse('zeitlabs_payments:course-price')
         course_id = 'course-v1:org1+1+1'
@@ -252,8 +251,7 @@ class CoursePriceViewTest(APITestCase):
             currency='IQD',
         )
 
-        from common.djangoapps.course_modes.models import CourseMode
-        from opaque_keys.edx.keys import CourseKey
+        # CourseMode and CourseKey are imported at module level
 
         course_key = CourseKey.from_string(course_id)
         CourseMode.objects.create(
@@ -292,9 +290,6 @@ class CoursePriceViewTest(APITestCase):
         Verify cache invalidation handler handles missing CourseMode gracefully.
         Tests the edge case where course_mode filter returns None.
         """
-        from common.djangoapps.course_modes.models import CourseMode
-        from opaque_keys.edx.keys import CourseKey
-
         url = reverse('zeitlabs_payments:course-price')
         course_id = 'course-v1:org1+orphan2+2024'
         CourseOverview.objects.create(

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -1,6 +1,9 @@
 """Test cache utilities."""
 
+from unittest.mock import Mock
+
 from common.djangoapps.course_modes.models import CourseMode
+from django.core.cache import cache
 from django.test import TestCase
 from opaque_keys.edx.keys import CourseKey
 
@@ -8,6 +11,7 @@ from zeitlabs_payments.cache_utils import (
     CACHE_TIMEOUT,
     get_course_price_cache_key,
     invalidate_course_price_cache,
+    invalidate_on_course_mode_change,
 )
 from zeitlabs_payments.models import CatalogueItem
 
@@ -24,7 +28,7 @@ class CacheUtilsTest(TestCase):
 
     def test_invalidate_course_price_cache(self) -> None:
         """Verify cache invalidation."""
-        from django.core.cache import cache
+        # using module-level `cache`
 
         course_id = 'course-v1:org+course+run'
         cache_key = get_course_price_cache_key(course_id)
@@ -37,7 +41,7 @@ class CacheUtilsTest(TestCase):
 
     def test_invalidate_on_catalogue_item_change_with_ref_id(self) -> None:
         """Verify cache invalidation when CatalogueItem with item_ref_id is saved."""
-        from django.core.cache import cache
+        # using module-level `cache`
 
         course_id = 'course-v1:test+course+run'
         cache_key = get_course_price_cache_key(course_id)
@@ -60,7 +64,7 @@ class CacheUtilsTest(TestCase):
 
         This tests the edge case where instance.item_ref_id is None.
         """
-        from django.core.cache import cache
+        # using module-level `cache`
 
         course_id = 'course-v1:test+course+run2'
         cache_key = get_course_price_cache_key(course_id)
@@ -80,7 +84,7 @@ class CacheUtilsTest(TestCase):
 
     def test_invalidate_on_course_mode_change_with_course_id(self) -> None:
         """Verify cache invalidation when CourseMode with course_id is saved."""
-        from django.core.cache import cache
+        # using module-level `cache`
 
         course_id = 'course-v1:test+course+run3'
         cache_key = get_course_price_cache_key(course_id)
@@ -124,9 +128,7 @@ class CacheUtilsTest(TestCase):
         This uses mocking to test the edge case where course_id might be None
         (e.g., if database constraints change in the future).
         """
-        from django.core.cache import cache
-        from unittest.mock import Mock
-
+        # using module-level `cache` and `Mock`
         course_id = 'course-v1:test+course+run5'
         cache_key = get_course_price_cache_key(course_id)
         cache.set(cache_key, {'test': 'data'}, CACHE_TIMEOUT)
@@ -134,8 +136,6 @@ class CacheUtilsTest(TestCase):
         mock_mode = Mock(spec=CourseMode)
         mock_mode.course_id = None
         mock_mode.sku = 'mock-sku'
-
-        from zeitlabs_payments.cache_utils import invalidate_on_course_mode_change
 
         invalidate_on_course_mode_change(CourseMode, mock_mode)
 

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -1,0 +1,142 @@
+"""Test cache utilities."""
+
+from common.djangoapps.course_modes.models import CourseMode
+from django.test import TestCase
+from opaque_keys.edx.keys import CourseKey
+
+from zeitlabs_payments.cache_utils import (
+    CACHE_TIMEOUT,
+    get_course_price_cache_key,
+    invalidate_course_price_cache,
+)
+from zeitlabs_payments.models import CatalogueItem
+
+
+class CacheUtilsTest(TestCase):
+    """Tests for cache utility functions."""
+
+    def test_get_course_price_cache_key(self) -> None:
+        """Verify cache key generation."""
+        course_id = 'course-v1:org+course+run'
+        cache_key = get_course_price_cache_key(course_id)
+
+        self.assertEqual(cache_key, f'course_price:{course_id}')
+
+    def test_invalidate_course_price_cache(self) -> None:
+        """Verify cache invalidation."""
+        from django.core.cache import cache
+
+        course_id = 'course-v1:org+course+run'
+        cache_key = get_course_price_cache_key(course_id)
+
+        cache.set(cache_key, {'test': 'data'}, CACHE_TIMEOUT)
+        self.assertIsNotNone(cache.get(cache_key))
+
+        invalidate_course_price_cache(course_id)
+        self.assertIsNone(cache.get(cache_key))
+
+    def test_invalidate_on_catalogue_item_change_with_ref_id(self) -> None:
+        """Verify cache invalidation when CatalogueItem with item_ref_id is saved."""
+        from django.core.cache import cache
+
+        course_id = 'course-v1:test+course+run'
+        cache_key = get_course_price_cache_key(course_id)
+        cache.set(cache_key, {'test': 'data'}, CACHE_TIMEOUT)
+
+        CatalogueItem.objects.create(
+            sku='test-sku',
+            type=CatalogueItem.ItemType.PAID_COURSE,
+            title='Test Item',
+            item_ref_id=course_id,
+            price=100,
+            currency='IQD',
+        )
+
+        self.assertIsNone(cache.get(cache_key))
+
+    def test_invalidate_on_catalogue_item_change_without_ref_id(self) -> None:
+        """
+        Verify that invalidating without item_ref_id doesn't crash.
+
+        This tests the edge case where instance.item_ref_id is None.
+        """
+        from django.core.cache import cache
+
+        course_id = 'course-v1:test+course+run2'
+        cache_key = get_course_price_cache_key(course_id)
+        cache.set(cache_key, {'test': 'data'}, CACHE_TIMEOUT)
+
+        CatalogueItem.objects.create(
+            sku='test-sku-no-ref',
+            type=CatalogueItem.ItemType.PAID_COURSE,
+            title='Test Item No Ref',
+            item_ref_id='',  # Empty ref_id
+            price=100,
+            currency='IQD',
+        )
+
+        empty_cache_key = get_course_price_cache_key('')
+        self.assertIsNone(cache.get(empty_cache_key))
+
+    def test_invalidate_on_course_mode_change_with_course_id(self) -> None:
+        """Verify cache invalidation when CourseMode with course_id is saved."""
+        from django.core.cache import cache
+
+        course_id = 'course-v1:test+course+run3'
+        cache_key = get_course_price_cache_key(course_id)
+        cache.set(cache_key, {'test': 'data'}, CACHE_TIMEOUT)
+
+        course_key_obj = CourseKey.from_string(course_id)
+        CourseMode.objects.create(
+            course_id=course_key_obj,
+            mode_slug='verified',
+            mode_display_name='Verified',
+            sku='test-sku-mode',
+            min_price=50,
+        )
+
+        self.assertIsNone(cache.get(cache_key))
+
+    def test_invalidate_on_course_mode_change_without_course_id(self) -> None:
+        """
+        Verify that invalidating without course_id doesn't crash.
+
+        This tests the edge case where instance.course_id is None.
+        """
+
+        course_id = 'course-v1:test+course+run4'
+        course_key_obj = CourseKey.from_string(course_id)
+
+        mode = CourseMode.objects.create(
+            course_id=course_key_obj,
+            mode_slug='honor',
+            mode_display_name='Honor',
+            sku='test-sku-honor',
+            min_price=0,
+        )
+
+        self.assertIsNotNone(mode.course_id)
+
+    def test_invalidate_on_course_mode_with_none_course_id_mock(self) -> None:
+        """
+        Verify cache invalidation handles None course_id gracefully.
+
+        This uses mocking to test the edge case where course_id might be None
+        (e.g., if database constraints change in the future).
+        """
+        from django.core.cache import cache
+        from unittest.mock import Mock
+
+        course_id = 'course-v1:test+course+run5'
+        cache_key = get_course_price_cache_key(course_id)
+        cache.set(cache_key, {'test': 'data'}, CACHE_TIMEOUT)
+
+        mock_mode = Mock(spec=CourseMode)
+        mock_mode.course_id = None
+        mock_mode.sku = 'mock-sku'
+
+        from zeitlabs_payments.cache_utils import invalidate_on_course_mode_change
+
+        invalidate_on_course_mode_change(CourseMode, mock_mode)
+
+        self.assertIsNotNone(cache.get(cache_key))

--- a/zeitlabs_payments/api_views.py
+++ b/zeitlabs_payments/api_views.py
@@ -98,7 +98,7 @@ class CoursePriceView(APIView):
             return Response(cached_data, status=status.HTTP_200_OK)
 
         try:
-            course = CourseOverview.objects.get(id=course_key)
+            course = CourseOverview.objects.get(id=course_key, visible_to_staff_only=False)
         except CourseOverview.DoesNotExist:
             logger.warning(f'Course not found for id: {course_id}')
             return Response(

--- a/zeitlabs_payments/api_views.py
+++ b/zeitlabs_payments/api_views.py
@@ -1,0 +1,114 @@
+"""API views for anonymous access to course pricing information."""
+
+import logging
+from typing import Any
+
+from common.djangoapps.course_modes.models import CourseMode
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from zeitlabs_payments.serializers import CoursePriceSerializer
+
+logger = logging.getLogger(__name__)
+
+
+class CoursePriceView(APIView):
+    """
+    API view for fetching course pricing information.
+
+    This API is accessible to anonymous users and returns payment information
+    for a single course including available modes, prices, and SKUs.
+    """
+
+    permission_classes = [AllowAny]
+
+    def get(self, request: Any) -> Response:
+        """
+        Retrieve pricing information for a course by course_id.
+
+        Query Parameters:
+            course_id (str): Course ID in format 'course-v1:org+course+run'
+
+        Returns:
+            Response with course pricing data including:
+                - course: Course details (name, id, image, org, run)
+                - pricing_modes: List of available pricing modes with:
+                    - mode_slug: The mode identifier (e.g., 'verified', 'professional')
+                    - mode_display_name: Human-readable mode name
+                    - price: Price for this mode
+                    - currency: Currency code
+                    - sku: SKU for checkout / payment
+
+        Example Response:
+        {
+            'course': {
+                'course_id': 'course-v1:org+course+run',
+                'course_name': 'Introduction to Python',
+                'course_image': 'https://example.com/image.jpg',
+                'org': 'org',
+                'run': 'run'
+            },
+            'pricing_modes': [
+                {
+                    'mode_slug': 'verified',
+                    'mode_display_name': 'Verified Certificate',
+                    'price': 99.99,
+                    'currency': 'IQD',
+                    'sku': 'course-v1:org+course+run-verified'
+                },
+                {
+                    'mode_slug': 'no-id-professional',
+                    'mode_display_name': 'Professional Certificate',
+                    'price': 199.99,
+                    'currency': 'IQD',
+                    'sku': 'course-v1:org+course+run-professional'
+                }
+            ]
+        }
+        """
+        course_id = request.query_params.get('course_id')
+
+        if not course_id:
+            return Response(
+                {'error': 'course_id parameter is required'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            course_key = CourseKey.from_string(course_id)
+        except (InvalidKeyError, ValueError) as exc:
+            logger.error(f'Invalid course_id format: {course_id} - {exc}')
+            return Response(
+                {'error': f'Invalid course_id format: {course_id}'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            course = CourseOverview.objects.get(id=course_key)
+        except CourseOverview.DoesNotExist:
+            logger.warning(f'Course not found for id: {course_id}')
+            return Response(
+                {'error': f'Course not found: {course_id}'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        modes = CourseMode.objects.filter(
+            course_id=course_key, sku__isnull=False
+        ).select_related('course')
+
+        if not modes.exists():
+            logger.warning(f'No pricing modes found for course: {course_id}')
+            return Response(
+                {'error': f'No pricing modes available for course: {course_id}'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        data = CoursePriceSerializer(
+            course, context={'request': request, 'modes': modes}
+        ).data
+        return Response(data, status=status.HTTP_200_OK)

--- a/zeitlabs_payments/api_views.py
+++ b/zeitlabs_payments/api_views.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any
 
 from common.djangoapps.course_modes.models import CourseMode
+from django.core.cache import cache
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -12,6 +13,10 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from zeitlabs_payments.cache_utils import (
+    CACHE_TIMEOUT,
+    get_course_price_cache_key,
+)
 from zeitlabs_payments.models import CatalogueItem
 from zeitlabs_payments.serializers import CoursePriceSerializer
 
@@ -89,6 +94,12 @@ class CoursePriceView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
+        cache_key = get_course_price_cache_key(course_id)
+        cached_data = cache.get(cache_key)
+        if cached_data:
+            logger.debug(f'Cache hit for course: {course_id}')
+            return Response(cached_data, status=status.HTTP_200_OK)
+
         try:
             course = CourseOverview.objects.get(id=course_key)
         except CourseOverview.DoesNotExist:
@@ -141,4 +152,8 @@ class CoursePriceView(APIView):
         data = CoursePriceSerializer(
             course, context={'request': request, 'pricing_data': pricing_data}
         ).data
+
+        cache.set(cache_key, data, CACHE_TIMEOUT)
+        logger.debug(f'Cache set for course: {course_id}')
+
         return Response(data, status=status.HTTP_200_OK)

--- a/zeitlabs_payments/api_views.py
+++ b/zeitlabs_payments/api_views.py
@@ -13,10 +13,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from zeitlabs_payments.cache_utils import (
-    CACHE_TIMEOUT,
-    get_course_price_cache_key,
-)
+from zeitlabs_payments.cache_utils import CACHE_TIMEOUT, get_course_price_cache_key
 from zeitlabs_payments.models import CatalogueItem
 from zeitlabs_payments.serializers import CoursePriceSerializer
 

--- a/zeitlabs_payments/api_views.py
+++ b/zeitlabs_payments/api_views.py
@@ -96,12 +96,9 @@ class CoursePriceView(APIView):
                 {'error': f'Course not found: {course_id}'},
                 status=status.HTTP_404_NOT_FOUND,
             )
+        modes = list(CourseMode.objects.filter(course_id=course_key, sku__isnull=False))
 
-        modes = CourseMode.objects.filter(
-            course_id=course_key, sku__isnull=False
-        ).select_related('course')
-
-        if not modes.exists():
+        if not modes:
             logger.warning(f'No pricing modes found for course: {course_id}')
             return Response(
                 {'error': f'No pricing modes available for course: {course_id}'},

--- a/zeitlabs_payments/api_views.py
+++ b/zeitlabs_payments/api_views.py
@@ -12,6 +12,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from zeitlabs_payments.models import CatalogueItem
 from zeitlabs_payments.serializers import CoursePriceSerializer
 
 logger = logging.getLogger(__name__)
@@ -96,16 +97,48 @@ class CoursePriceView(APIView):
                 {'error': f'Course not found: {course_id}'},
                 status=status.HTTP_404_NOT_FOUND,
             )
-        modes = list(CourseMode.objects.filter(course_id=course_key, sku__isnull=False))
 
-        if not modes:
+        catalogue_items = list(
+            CatalogueItem.objects.filter(
+                item_ref_id=str(course_key), type=CatalogueItem.ItemType.PAID_COURSE
+            )
+        )
+
+        if not catalogue_items:
             logger.warning(f'No pricing modes found for course: {course_id}')
             return Response(
                 {'error': f'No pricing modes available for course: {course_id}'},
                 status=status.HTTP_404_NOT_FOUND,
             )
 
+        course_modes = {
+            mode.sku: mode
+            for mode in CourseMode.objects.filter(
+                course_id=course_key, sku__in=[item.sku for item in catalogue_items]
+            )
+        }
+
+        pricing_data = []
+        for item in catalogue_items:
+            mode = course_modes.get(item.sku)
+            if mode:
+                pricing_data.append(
+                    {
+                        'catalogue_item': item,
+                        'course_mode': mode,
+                    }
+                )
+
+        if not pricing_data:
+            logger.warning(
+                f'No matching course modes found for catalogue items: {course_id}'
+            )
+            return Response(
+                {'error': f'No pricing modes available for course: {course_id}'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
         data = CoursePriceSerializer(
-            course, context={'request': request, 'modes': modes}
+            course, context={'request': request, 'pricing_data': pricing_data}
         ).data
         return Response(data, status=status.HTTP_200_OK)

--- a/zeitlabs_payments/cache_utils.py
+++ b/zeitlabs_payments/cache_utils.py
@@ -1,0 +1,82 @@
+"""Cache utilities for course pricing data."""
+
+import logging
+from common.djangoapps.course_modes.models import CourseMode
+from django.core.cache import cache
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
+
+from zeitlabs_payments.models import CatalogueItem
+
+logger = logging.getLogger(__name__)
+
+# Cache timeout: 1 hour (3600 seconds)
+# Cache is invalidated when prices change, so this is just a fallback
+CACHE_TIMEOUT = 3600
+
+__all__ = [
+    'get_course_price_cache_key',
+    'invalidate_course_price_cache',
+    'CACHE_TIMEOUT',
+]
+
+
+def get_course_price_cache_key(course_id: str) -> str:
+    """
+    Generate cache key for course pricing data.
+
+    :param course_id: Course ID string
+    :return: Cache key
+    """
+    return f'course_price:{course_id}'
+
+
+def invalidate_course_price_cache(course_id: str) -> None:
+    """
+    Invalidate cache for a specific course.
+
+    :param course_id: Course ID to invalidate
+    """
+    cache_key = get_course_price_cache_key(course_id)
+    cache.delete(cache_key)
+    logger.debug(f'Invalidated cache for course: {course_id}')
+
+
+@receiver(post_save, sender=CatalogueItem)
+@receiver(post_delete, sender=CatalogueItem)
+def invalidate_on_catalogue_item_change(sender, instance, **kwargs) -> None:
+    """
+    Invalidate course price cache when a CatalogueItem is created, updated, or deleted.
+
+    This ensures that any price changes are immediately reflected in the API.
+
+    :param sender: Model class sending the signal
+    :param instance: CatalogueItem instance
+    """
+    if instance.item_ref_id:
+        invalidate_course_price_cache(instance.item_ref_id)
+        logger.info(
+            f'Cache invalidated for course {instance.item_ref_id} '
+            f'due to CatalogueItem change (sku: {instance.sku})'
+        )
+
+
+@receiver(post_save, sender=CourseMode)
+@receiver(post_delete, sender=CourseMode)
+def invalidate_on_course_mode_change(sender, instance, **kwargs) -> None:
+    """
+    Invalidate course price cache when a CourseMode is created, updated, or deleted.
+
+    This ensures that mode detail changes (mode_slug, mode_display_name) are
+    immediately reflected in the API.
+
+    :param sender: Model class sending the signal
+    :param instance: CourseMode instance
+    """
+    if instance.course_id:
+        course_id = str(instance.course_id)
+        invalidate_course_price_cache(course_id)
+        logger.info(
+            f'Cache invalidated for course {course_id} '
+            f'due to CourseMode change (sku: {instance.sku})'
+        )

--- a/zeitlabs_payments/cache_utils.py
+++ b/zeitlabs_payments/cache_utils.py
@@ -1,9 +1,11 @@
 """Cache utilities for course pricing data."""
 
 import logging
+from typing import Any
+
 from common.djangoapps.course_modes.models import CourseMode
 from django.core.cache import cache
-from django.db.models.signals import post_save, post_delete
+from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
 from zeitlabs_payments.models import CatalogueItem
@@ -44,7 +46,10 @@ def invalidate_course_price_cache(course_id: str) -> None:
 
 @receiver(post_save, sender=CatalogueItem)
 @receiver(post_delete, sender=CatalogueItem)
-def invalidate_on_catalogue_item_change(sender, instance, **kwargs) -> None:
+# pylint: disable=unused-argument
+def invalidate_on_catalogue_item_change(
+    sender: type, instance: CatalogueItem, **kwargs: Any
+) -> None:
     """
     Invalidate course price cache when a CatalogueItem is created, updated, or deleted.
 
@@ -63,7 +68,10 @@ def invalidate_on_catalogue_item_change(sender, instance, **kwargs) -> None:
 
 @receiver(post_save, sender=CourseMode)
 @receiver(post_delete, sender=CourseMode)
-def invalidate_on_course_mode_change(sender, instance, **kwargs) -> None:
+# pylint: disable=unused-argument
+def invalidate_on_course_mode_change(
+    sender: type, instance: CourseMode, **kwargs: Any
+) -> None:
     """
     Invalidate course price cache when a CourseMode is created, updated, or deleted.
 

--- a/zeitlabs_payments/serializers.py
+++ b/zeitlabs_payments/serializers.py
@@ -164,7 +164,9 @@ class CartItemSerializer(serializers.ModelSerializer):
         if callable(handler_method):
             return handler_method(obj)  # pylint: disable=not-callable
 
-        logger.warning(f"No handler implemented for item type '{item_type}'. Returning empty details.")
+        logger.warning(
+            f'No handler implemented for item type \'{item_type}\'. Returning empty details.'
+        )
         return {}
 
     def _get_paid_course_details(self, obj: CartItem) -> dict:
@@ -196,7 +198,16 @@ class CartSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Cart
-        fields = ['id', 'user', 'status', 'created_at', 'items', 'total', 'currency', 'invoice']
+        fields = [
+            'id',
+            'user',
+            'status',
+            'created_at',
+            'items',
+            'total',
+            'currency',
+            'invoice',
+        ]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize serializer and remove invoice from fields if not required."""
@@ -276,21 +287,26 @@ class CoursePriceSerializer(serializers.Serializer):  # pylint: disable=abstract
         """
         Return list of available pricing modes for the course.
 
-        :param obj: CourseOverview instance
-        :return: List of pricing mode dictionaries
-        """
-        modes = self.context.get('modes', [])
-        pricing_data = []
+        Combines CatalogueItem (localized price/currency) with CourseMode (mode details).
 
-        for mode in modes:
-            pricing_data.append(
+        :param obj: CourseOverview instance
+        :return: List of pricing mode dictionaries with localized pricing
+        """
+        pricing_data = self.context.get('pricing_data', [])
+        result = []
+
+        for item_data in pricing_data:
+            catalogue_item = item_data['catalogue_item']
+            course_mode = item_data['course_mode']
+
+            result.append(
                 {
-                    'mode_slug': mode.mode_slug,
-                    'mode_display_name': mode.mode_display_name,
-                    'price': mode.min_price,
-                    'currency': mode.currency,
-                    'sku': mode.sku,
+                    'mode_slug': course_mode.mode_slug,
+                    'mode_display_name': course_mode.mode_display_name,
+                    'price': catalogue_item.price,  # Localized price from CatalogueItem
+                    'currency': catalogue_item.currency,  # Localized currency from CatalogueItem
+                    'sku': catalogue_item.sku,
                 }
             )
 
-        return pricing_data
+        return result

--- a/zeitlabs_payments/serializers.py
+++ b/zeitlabs_payments/serializers.py
@@ -1,4 +1,5 @@
 """zeitlabs payments serializers."""
+
 import logging
 from typing import Any, List, Optional
 
@@ -249,20 +250,6 @@ class CartSerializer(serializers.ModelSerializer):
             'email': user.email,
             'full_name': user.get_full_name(),
         }
-
-
-class PricingModeSerializer(serializers.Serializer):  # pylint: disable=abstract-method
-    """
-    Serializer for pricing mode information.
-
-    This is a read-only serializer, so create() and update() are not implemented.
-    """
-
-    mode_slug = serializers.CharField()
-    mode_display_name = serializers.CharField()
-    price = serializers.DecimalField(max_digits=10, decimal_places=2)
-    currency = serializers.CharField()
-    sku = serializers.CharField()
 
 
 class CoursePriceSerializer(serializers.Serializer):  # pylint: disable=abstract-method

--- a/zeitlabs_payments/serializers.py
+++ b/zeitlabs_payments/serializers.py
@@ -249,3 +249,61 @@ class CartSerializer(serializers.ModelSerializer):
             'email': user.email,
             'full_name': user.get_full_name(),
         }
+
+
+class PricingModeSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """
+    Serializer for pricing mode information.
+
+    This is a read-only serializer, so create() and update() are not implemented.
+    """
+
+    mode_slug = serializers.CharField()
+    mode_display_name = serializers.CharField()
+    price = serializers.DecimalField(max_digits=10, decimal_places=2)
+    currency = serializers.CharField()
+    sku = serializers.CharField()
+
+
+class CoursePriceSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """
+    Serializer for course pricing information.
+
+    Returns course details and available pricing modes for anonymous users.
+    This is a read-only serializer, so create() and update() are not implemented.
+    """
+
+    course = serializers.SerializerMethodField()
+    pricing_modes = serializers.SerializerMethodField()
+
+    def get_course(self, obj: CourseOverview) -> dict:
+        """
+        Return serialized course information.
+
+        :param obj: CourseOverview instance
+        :return: Course data dictionary
+        """
+        return CourseSerializer(obj, context=self.context).data
+
+    def get_pricing_modes(self, obj: CourseOverview) -> List[dict]:  # pylint: disable=unused-argument
+        """
+        Return list of available pricing modes for the course.
+
+        :param obj: CourseOverview instance
+        :return: List of pricing mode dictionaries
+        """
+        modes = self.context.get('modes', [])
+        pricing_data = []
+
+        for mode in modes:
+            pricing_data.append(
+                {
+                    'mode_slug': mode.mode_slug,
+                    'mode_display_name': mode.mode_display_name,
+                    'price': mode.min_price,
+                    'currency': mode.currency,
+                    'sku': mode.sku,
+                }
+            )
+
+        return pricing_data

--- a/zeitlabs_payments/urls.py
+++ b/zeitlabs_payments/urls.py
@@ -1,47 +1,47 @@
 """
 URLs for zeitlabs_payments.
 """
+
 from django.urls import re_path
 
-from zeitlabs_payments import views
+from zeitlabs_payments import api_views, views
 from zeitlabs_payments.providers.manual_payment import views as manual_payment_views
 
 app_name = 'zeitlabs_payments'
 
 
 urlpatterns: list = [
-    re_path(
-        r'^checkout/v1/checkout/$',
-        views.CheckoutView.as_view(),
-        name='checkout'
-    ),
+    re_path(r'^checkout/v1/checkout/$', views.CheckoutView.as_view(), name='checkout'),
     re_path(
         r'^payment/v1/initiate/(?P<provider>[\w-]+)/(?P<cart_id>[0-9a-f-]+)/$',
         views.InitiatePaymentView.as_view(),
-        name='initiate-payment'
+        name='initiate-payment',
     ),
     re_path(
         r'^payment/v1/error/(.+)/$',
         views.PaymentErrorView.as_view(),
-        name='payment-error'
+        name='payment-error',
     ),
     re_path(
         r'^payment/v1/decline/(.+)/$',
         views.PaymentDeclineView.as_view(),
-        name='payment-decline'
+        name='payment-decline',
     ),
     re_path(
         r'^payment/v1/success/(.+)/$',
         views.PaymentSuccessView.as_view(),
-        name='payment-success'
+        name='payment-success',
     ),
-
-    re_path(
-        r'^payment/v1/invoice/(.+)/$',
-        views.InvoiceView.as_view(),
-        name='invoice'
-    ),
-
+    re_path(r'^payment/v1/invoice/(.+)/$', views.InvoiceView.as_view(), name='invoice'),
     re_path(r'^api/cart/v1/cart/$', views.CartView.as_view(), name='cart-add'),
-    re_path(r'^api/payment/v1/manual/$', manual_payment_views.ManualPaymentView.as_view(), name='manual-payment'),
+    re_path(
+        r'^api/payment/v1/manual/$',
+        manual_payment_views.ManualPaymentView.as_view(),
+        name='manual-payment',
+    ),
+    re_path(
+        r'^api/courses/v1/price/$',
+        api_views.CoursePriceView.as_view(),
+        name='course-price',
+    ),
 ]


### PR DESCRIPTION
- Implements anonymous-accessible API endpoint for fetching course pricing information
- Returns course details and available pricing modes with SKUs
- Includes comprehensive test coverage
## Testing
- All tests pass (5/5)
- All quality checks pass (flake8, pylint, mypy)
- Tested manually with multiple course IDs
## API Endpoint
```
GET /api/courses/v1/price/?course_id=<course_id>
```
**Example Response:**
```json
{
    "course": {
        "course_id": "course-v1:eduba+CS101+2026_1",
        "course_name": "Introduction to C programming language",
        "course_image": "http://...",
        "org": "eduba",
        "run": "2026_1"
    },
    "pricing_modes": [{
        "mode_slug": "no-id-professional",
        "mode_display_name": "Introduction to C Programming Language",
        "price": 100,
        "currency": "usd",
        "sku": "EDUBA-CS101-2026"
    }]
}
```

## Screenshot

<img width="1437" height="803" alt="image" src="https://github.com/user-attachments/assets/be6ed90f-4d56-431d-9054-5f6f4a1db007" />

## Jira 
[EDB-67](https://zeitlabs.atlassian.net/browse/EDB-67)
